### PR TITLE
Systemd and nginx production setup and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ git submodule init
 git submodule update
 pip install -r REQUIREMENTS
 ~~~
+## Starting the server
+
+~~~
+cd bin
+python tai-server.py
+~~~
+
+By the default, the server is listening on TCP port 8889.
 
 # Alternative Installation
 
@@ -27,6 +35,7 @@ This method involves:
  - creating a python virtual environment
  - installation of TAI
  - systemd configuraion of (arbitrarily) four instances
+ - configuring nginx as a reverse proxy to four instances
 
 Installing a few dependencies
 ~~~
@@ -59,15 +68,19 @@ sudo cp /home/tai/threat-actor-intelligence-server/debian/tai.target /etc/system
 sudo systemctl daemon-reload
 ~~~
 
-
-# Starting the server
-
+configuring nginx as a reverse proxy to four instances
 ~~~
-cd bin
-python tai-server.py
+sudo rm /etc/nginx/site-enabled/default
+sudo cp /home/tai/threat-actor-intelligence-server/debian/nginx-tai.conf /etc/nginx/sites-available/
+sudo ln -s /etc/nginx/sites-available/nginx-tai.conf /etc/nginx/sites-enabled/
 ~~~
 
-By the default, the server is listening on TCP port 8889.
+Lastly, configure systemd to start the TAI servers and nginx automatically
+~~~
+sudo systemctl enable tai.target
+sudo systemctl enable nginx
+~~~
+
 
 # API and public API
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,47 @@ git submodule update
 pip install -r REQUIREMENTS
 ~~~
 
+# Alternative Installation
+
+This method involves:
+ - installing a few dependencies
+ - creating a dedicated, unprivileged, user to run the TAI server(s)
+ - creating a python virtual environment
+ - installation of TAI
+ - systemd configuraion of (arbitrarily) four instances
+
+Installing a few dependencies
+~~~
+sudo apt install virtualenv git python3-pip
+~~~
+
+Create a dedicated, unprivileged, user to run the TAI server(s)
+~~~
+sudo adduser tai
+~~~
+
+Two steps together; creating a python virtual environment _and_ installation of TAI
+~~~
+sudo su tai 
+virtualenv tai-env
+source ./tai-env/bin/activate
+cd
+git clone https://github.com/MISP/threat-actor-intelligence-server
+cd threat-actor-intelligence-server
+git submodule init
+git submodule update
+pip install -r REQUIREMENTS
+exit
+~~~
+
+systemd configuraion for a group of four instances of TAI
+~~~
+sudo cp /home/tai/threat-actor-intelligence-server/debian/tai@.service /lib/systemd/system/
+sudo cp /home/tai/threat-actor-intelligence-server/debian/tai.target /etc/systemd/system/
+sudo systemctl daemon-reload
+~~~
+
+
 # Starting the server
 
 ~~~

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Create a dedicated, unprivileged, user to run the TAI server(s)
 sudo adduser tai
 ~~~
 
-Two steps together; creating a python virtual environment _and_ installation of TAI
+Create and activate a python virtual environment called _tai-env_
 ~~~
 sudo su tai 
 virtualenv tai-env
 source ./tai-env/bin/activate
+~~~
+
+Installation of TAI in the home directory of the user `tai`
+~~~
 cd
 git clone https://github.com/MISP/threat-actor-intelligence-server
 cd threat-actor-intelligence-server

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This method involves:
 
 Installing a few dependencies
 ~~~
-sudo apt install virtualenv git python3-pip
+sudo apt install virtualenv git python3-pip nginx
 ~~~
 
 Create a dedicated, unprivileged, user to run the TAI server(s)

--- a/debian/nginx-tai.conf
+++ b/debian/nginx-tai.conf
@@ -1,0 +1,14 @@
+upstream backends {
+    server 127.0.0.1:8000;
+    server 127.0.0.1:8001;
+    server 127.0.0.1:8002;
+    server 127.0.0.1:8003;
+}
+    
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://frontends;
+    }
+}

--- a/debian/nginx-tai.conf
+++ b/debian/nginx-tai.conf
@@ -9,6 +9,6 @@ server {
     listen 80;
 
     location / {
-        proxy_pass http://frontends;
+        proxy_pass http://backends;
     }
 }

--- a/debian/tai.target
+++ b/debian/tai.target
@@ -1,0 +1,6 @@
+Unit]
+Description=TAI Servers
+Requires=tai@8000.service tai@8001.service tai@8002.service tai@8003.service
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/tai@.service
+++ b/debian/tai@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Threat Actor Intelligence Server
+PartOf=tai.target
+
+[Service]
+WorkingDirectory=/home/tai/threat-actor-intelligence-server/bin
+ExecStart=/home/tai/tai-env/bin/python3 tai-server.py --port=%I --address='127.0.0.1'
+User=tai
+Restart=on-failure
+Type=simple
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd target and service files, and an nginx conf file to facilitate running a collection (four) tai-servers behind an nginx proxy

Instructions consist of updates to README.md 
- The 'Starting the server' section is now a subsection of the 'Installation' section.
- A new 'Alternative Installation' describes creating a new user, a virtual env, and placing config files in the appropriate locations

Systemd configuration has two parts
- a port-parameterised `.service` file: `tai@.service` to run a the tai-server in its venv on the specified port
- a `.target` file: `tai.target`to allow systemctl control of a group of (currently) four instances of tai-server.py

nginx configuration is a bare bones reverse proxy to localhost 
